### PR TITLE
refactor: rename config to millenniumConfig to avoid conflicts

### DIFF
--- a/home-modules/steam.nix
+++ b/home-modules/steam.nix
@@ -19,7 +19,7 @@ in
         example = pkgs.milleniumThemes.metro;
       };
 
-    config =
+    millenniumConfig =
       with lib;
       mkOption {
         type = types.submodule {
@@ -61,7 +61,7 @@ in
         ];
       */
 
-      programs.steam.config = lib.mkMerge [
+      programs.steam.millenniumConfig = lib.mkMerge [
         {
           general = {
             checkForMillenniumUpdates = false;
@@ -101,8 +101,8 @@ in
     }
 
     {
-      xdg.configFile."millennium/config.json" = lib.mkIf (cfg.config != { }) {
-        source = jsonFormat.generate "config.json" cfg.config;
+      xdg.configFile."millennium/config.json" = lib.mkIf (cfg.millenniumConfig != { }) {
+        source = jsonFormat.generate "config.json" cfg.millenniumConfig;
         force = true;
       };
     }


### PR DESCRIPTION
Fixes #2 

I believe  a hard switch like this is fine. I am the first person to give this repo a Star, and its only like 2 weeks old. I doubt more than a handful of people use it currently, so investing the effort for a proper deprecation and switch seems really overkill.