### PR TITLE
fix: avoid conflcts with other flakes that have optional stylix bahaviour

### DIFF
--- a/home-modules/steam.nix
+++ b/home-modules/steam.nix
@@ -9,7 +9,7 @@ let
   cfg = config.programs.steam;
   jsonFormat = pkgs.formats.json { };
 
-  stylixEnabled = osConfig.stylix.targets.steam.enable;
+  stylixEnabled = (config ? "stylix") && (osConfig.stylix.targets.steam.enable);
 in
 {
   options.programs.steam = {

--- a/modules/stylix.nix
+++ b/modules/stylix.nix
@@ -1,8 +1,10 @@
-{ config, lib, ... }:
+{ lib, config, ... }:
 {
-  options.stylix.targets.steam.enable = lib.mkOption {
-    description = "Millennium Steam";
-    type = lib.types.bool;
-    default = config.stylix.autoEnable or true;
+  options = lib.mkIf (config ? stylix) {
+    stylix.targets.steam.enable = lib.mkOption {
+      description = "Millennium Steam";
+      type = lib.types.bool;
+      default = config.stylix.autoEnable or false;
+    };
   };
 }


### PR DESCRIPTION
Make sure to only create stylix options when stylix is present. This prevents confusing other flakes systems that check if stylix is installed.

I also changed the logic a bit, because im 90% sure that was a mistake. The default for the enable option was config.stylix.autoEnable or true, which would mean, always true. That doesnt make much sense. So now if autoEnable is not set at all or something like that, it defaults to false. If i wanted to have my stylix themeing autoEnabled, i would have set it autoEnable to true after all. 

Fixes #3 