### PR TITLE
fix: avoid conflcts with other flakes that have optional stylix bahav…

### DIFF
--- a/home-modules/default.nix
+++ b/home-modules/default.nix
@@ -4,4 +4,10 @@ _: {
       ./steam.nix
     ];
   };
+
+  flake.homeManagerModules.stylix = {
+    imports = [
+      ./stylix.nix
+    ];
+  };
 }

--- a/home-modules/steam.nix
+++ b/home-modules/steam.nix
@@ -1,6 +1,5 @@
 {
   config,
-  osConfig,
   pkgs,
   lib,
   ...
@@ -8,8 +7,6 @@
 let
   cfg = config.programs.steam;
   jsonFormat = pkgs.formats.json { };
-
-  stylixEnabled = osConfig.stylix.targets.steam.enable;
 in
 {
   options.programs.steam = {
@@ -64,8 +61,6 @@ in
         ];
       */
 
-      programs.steam.theme = lib.mkIf stylixEnabled (lib.mkDefault pkgs.millenniumThemes.adwaita);
-
       programs.steam.config = lib.mkMerge [
         {
           general = {
@@ -85,10 +80,6 @@ in
 
         (lib.mkIf (cfg.theme != null) {
           themes.activeTheme = cfg.theme.pname or "custom-theme";
-        })
-
-        (lib.mkIf stylixEnabled {
-          themes.themeColors."adwaita" = (import ./stylix.nix { inherit lib config; }).default;
         })
       ];
     }

--- a/home-modules/stylix.nix
+++ b/home-modules/stylix.nix
@@ -1,81 +1,91 @@
 {
-  lib,
   config,
+  lib,
+  pkgs,
+  ...
 }:
-let
-  hexToRGB =
-    hex:
-    let
-      r = lib.fromHexString (builtins.substring 0 2 hex);
-      g = lib.fromHexString (builtins.substring 2 2 hex);
-      b = lib.fromHexString (builtins.substring 4 2 hex);
-    in
-    "${toString r}, ${toString g}, ${toString b}";
-in
-with config.lib.stylix.colors;
 {
-  default = {
-    "--adw-accent-bg-rbg" = hexToRGB base0D;
-    "--adw-accent-fg-rbg" = hexToRGB base00;
-    "--adw-accent-rgb" = hexToRGB base0D;
+  options.stylix.targets.millenniumSteam.enable =
+    config.lib.stylix.mkEnableTarget "Millennium Steam" true;
 
-    "--adw-destructive-bg-rgb" = hexToRGB base08;
-    "--adw-destructive-fg-rgb" = hexToRGB base00;
-    "--adw-destructive-rgb" = hexToRGB base08;
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.millenniumSteam.enable) {
+    programs.steam.theme = lib.mkDefault pkgs.millenniumThemes.adwaita;
 
-    "--adw-success-bg-rgb" = hexToRGB base0B;
-    "--adw-success-fg-rgb" = hexToRGB base00;
-    "--adw-success-rgb" = hexToRGB base0B;
+    programs.steam.config.themes.themeColors."adwaita" =
+      let
+        hexToRGB =
+          hex:
+          let
+            r = lib.fromHexString (builtins.substring 0 2 hex);
+            g = lib.fromHexString (builtins.substring 2 2 hex);
+            b = lib.fromHexString (builtins.substring 4 2 hex);
+          in
+          "${toString r}, ${toString g}, ${toString b}";
+      in
+      with config.lib.stylix.colors;
+      {
+        "--adw-accent-bg-rbg" = hexToRGB base0D;
+        "--adw-accent-fg-rbg" = hexToRGB base00;
+        "--adw-accent-rgb" = hexToRGB base0D;
 
-    "--adw-warning-bg-rgb" = hexToRGB base0E;
-    "--adw-warning-fg-rgb" = hexToRGB base00;
-    "--adw-warning-fg-a" = "0.8";
-    "--adw-warning-rgb" = hexToRGB base0E;
+        "--adw-destructive-bg-rgb" = hexToRGB base08;
+        "--adw-destructive-fg-rgb" = hexToRGB base00;
+        "--adw-destructive-rgb" = hexToRGB base08;
 
-    "--adw-error-bg-rgb" = hexToRGB base08;
-    "--adw-error-fg-rgb" = hexToRGB base00;
-    "--adw-error-rgb" = hexToRGB base08;
+        "--adw-success-bg-rgb" = hexToRGB base0B;
+        "--adw-success-fg-rgb" = hexToRGB base00;
+        "--adw-success-rgb" = hexToRGB base0B;
 
-    "--adw-window-bg-rgb" = hexToRGB base00;
-    "--adw-window-fg-rgb" = hexToRGB base05;
-    "--adw-view-bg-rgb" = hexToRGB base00;
-    "--adw-view-fg-rgb" = hexToRGB base05;
+        "--adw-warning-bg-rgb" = hexToRGB base0E;
+        "--adw-warning-fg-rgb" = hexToRGB base00;
+        "--adw-warning-fg-a" = "0.8";
+        "--adw-warning-rgb" = hexToRGB base0E;
 
-    "--adw-headerbar-bg-rgb" = hexToRGB base01;
-    "--adw-headerbar-fg-rgb" = hexToRGB base05;
-    "--adw-headerbar-border-rgb" = hexToRGB base01;
-    "--adw-headerbar-backdrop-rgb" = hexToRGB base00;
-    "--adw-headerbar-shade-rgb" = "0, 0, 0";
-    "--adw-headerbar-shade-a" = "0.9";
+        "--adw-error-bg-rgb" = hexToRGB base08;
+        "--adw-error-fg-rgb" = hexToRGB base00;
+        "--adw-error-rgb" = hexToRGB base08;
 
-    "--adw-sidebar-bg-rgb" = hexToRGB base01;
-    "--adw-sidebar-fg-rgb" = hexToRGB base05;
-    "--adw-sidebar-backdrop-rgb" = hexToRGB base00;
-    "--adw-sidebar-shade-rgb" = "0, 0, 0";
-    "--adw-sidebar-shade-a" = "0.36";
+        "--adw-window-bg-rgb" = hexToRGB base00;
+        "--adw-window-fg-rgb" = hexToRGB base05;
+        "--adw-view-bg-rgb" = hexToRGB base00;
+        "--adw-view-fg-rgb" = hexToRGB base05;
 
-    "--adw-secondary-sidebar-bg-rgb" = hexToRGB base01;
-    "--adw-secondary-sidebar-fg-rgb" = hexToRGB base05;
-    "--adw-secondary-sidebar-backdrop-rgb" = hexToRGB base00;
-    "--adw-secondary-sidebar-shade-rgb" = "0, 0, 0";
-    "--adw-secondary-sidebar-shade-a" = "0.36";
+        "--adw-headerbar-bg-rgb" = hexToRGB base01;
+        "--adw-headerbar-fg-rgb" = hexToRGB base05;
+        "--adw-headerbar-border-rgb" = hexToRGB base01;
+        "--adw-headerbar-backdrop-rgb" = hexToRGB base00;
+        "--adw-headerbar-shade-rgb" = "0, 0, 0";
+        "--adw-headerbar-shade-a" = "0.9";
 
-    "--adw-card-bg-rgb" = "0, 0, 0";
-    "--adw-card-bg-a" = "0.08";
-    "--adw-card-fg-rgb" = hexToRGB base05;
-    "--adw-card-shade-rgb" = "0, 0, 0";
-    "--adw-card-shade-a" = "0.36";
+        "--adw-sidebar-bg-rgb" = hexToRGB base01;
+        "--adw-sidebar-fg-rgb" = hexToRGB base05;
+        "--adw-sidebar-backdrop-rgb" = hexToRGB base00;
+        "--adw-sidebar-shade-rgb" = "0, 0, 0";
+        "--adw-sidebar-shade-a" = "0.36";
 
-    "--adw-dialog-bg-rgb" = hexToRGB base01;
-    "--adw-dialog-fg-rgb" = hexToRGB base05;
-    "--adw-popover-bg-rgb" = hexToRGB base01;
-    "--adw-popover-fg-rgb" = hexToRGB base05;
-    "--adw-popover-shade-rgb" = hexToRGB base01;
-    "--adw-popover-shade-a" = "0.36";
+        "--adw-secondary-sidebar-bg-rgb" = hexToRGB base01;
+        "--adw-secondary-sidebar-fg-rgb" = hexToRGB base05;
+        "--adw-secondary-sidebar-backdrop-rgb" = hexToRGB base00;
+        "--adw-secondary-sidebar-shade-rgb" = "0, 0, 0";
+        "--adw-secondary-sidebar-shade-a" = "0.36";
 
-    "--adw-thumbnail-bg-rgb" = hexToRGB base00;
-    "--adw-thumbnail-fg-rgb" = hexToRGB base05;
-    "--adw-shade-rgb" = "0, 0, 0";
-    "--adw-shade-a" = "0.36";
+        "--adw-card-bg-rgb" = "0, 0, 0";
+        "--adw-card-bg-a" = "0.08";
+        "--adw-card-fg-rgb" = hexToRGB base05;
+        "--adw-card-shade-rgb" = "0, 0, 0";
+        "--adw-card-shade-a" = "0.36";
+
+        "--adw-dialog-bg-rgb" = hexToRGB base01;
+        "--adw-dialog-fg-rgb" = hexToRGB base05;
+        "--adw-popover-bg-rgb" = hexToRGB base01;
+        "--adw-popover-fg-rgb" = hexToRGB base05;
+        "--adw-popover-shade-rgb" = hexToRGB base01;
+        "--adw-popover-shade-a" = "0.36";
+
+        "--adw-thumbnail-bg-rgb" = hexToRGB base00;
+        "--adw-thumbnail-fg-rgb" = hexToRGB base05;
+        "--adw-shade-rgb" = "0, 0, 0";
+        "--adw-shade-a" = "0.36";
+      };
   };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,31 +1,33 @@
 {
   lib,
-  pkgs,
   self,
   ...
 }:
 {
-  flake.nixosModules.default = {
-    imports = [
-      ./stylix.nix
-    ];
+  flake.nixosModules.default =
+    { options, pkgs, ... }:
+    lib.mkMerge [
+      (lib.optionalAttrs (options ? home-manager) {
+        home-manager.sharedModules = [
+          self.homeManagerModules.default
+        ]
+        ++ lib.optionals (options ? stylix) [ self.homeManagerModules.stylix ];
+      })
 
-    home-manager.sharedModules = [
-      self.homeManagerModules.default
-    ];
+      {
+        nixpkgs.overlays = [
+          self.overlays.default
+        ];
 
-    nixpkgs.overlays = [
-      self.overlays.default
-    ];
+        nix.settings.trusted-public-keys = [
+          "nixos-millennium.cachix.org-1:AaMK3uqfgzCUpjs7+gdHTwwaqkT/vvLMCnUKSY37QAQ="
+        ];
 
-    nix.settings.trusted-public-keys = [
-      "nixos-millennium.cachix.org-1:AaMK3uqfgzCUpjs7+gdHTwwaqkT/vvLMCnUKSY37QAQ="
-    ];
+        nix.settings.substituters = [
+          "https://nixos-millennium.cachix.org"
+        ];
 
-    nix.settings.substituters = [
-      "https://nixos-millennium.cachix.org"
+        programs.steam.package = lib.mkDefault pkgs.millennium-steam;
+      }
     ];
-
-    programs.steam.package = lib.mkDefault pkgs.millennium-steam;
-  };
 }

--- a/modules/stylix.nix
+++ b/modules/stylix.nix
@@ -1,8 +1,0 @@
-{ config, lib, ... }:
-{
-  options.stylix.targets.steam.enable = lib.mkOption {
-    description = "Millennium Steam";
-    type = lib.types.bool;
-    default = config.stylix.autoEnable or true;
-  };
-}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -35,6 +35,7 @@ in
 
       packages = {
         close-steam-session = pkgs.callPackage ./close-steam-session { };
-      } // (inputs.millennium.packages.${system} or {});
+      }
+      // (inputs.millennium.packages.${system} or { });
     };
 }


### PR DESCRIPTION
Move stylix configuration from `home-modules/steam.nix` to `home-modules/stylix.nix`. Add `homeManagerModules.stylix` and use it in `home-manager.sharedModules` if `options.stylix` exists. 

**Fixes:** https://github.com/re1n0/nixos-millennium/issues/3